### PR TITLE
Trigger to fully customize conditions and types of notices

### DIFF
--- a/Components/Bootstrap/ConditionsCollectionPass.php
+++ b/Components/Bootstrap/ConditionsCollectionPass.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Components\Bootstrap;
+
+use Shopware\Components\DependencyInjection\Compiler\TagReplaceTrait;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class ConditionsCollectionPass
+ */
+class ConditionsCollectionPass implements CompilerPassInterface
+{
+    use TagReplaceTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->replaceArgumentWithTaggedServices(
+            $container,
+            'frosh_environment_notice.services.conditions',
+            'frosh_environment_notice.condition',
+            0
+        );
+    }
+}

--- a/Components/Bootstrap/NoticeInjectActionCollectionPass.php
+++ b/Components/Bootstrap/NoticeInjectActionCollectionPass.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Components\Bootstrap;
+
+use Shopware\Components\DependencyInjection\Compiler\TagReplaceTrait;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class NoticeInjectActionCollectionPass
+ */
+class NoticeInjectActionCollectionPass implements CompilerPassInterface
+{
+    use TagReplaceTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->replaceArgumentWithTaggedServices(
+            $container,
+            'frosh_environment_notice.services.notice_inject_actions',
+            'frosh_environment_notice.notice_inject_action',
+            0
+        );
+    }
+}

--- a/Controllers/Backend/FroshEnvironmentNoticeEditorApi.php
+++ b/Controllers/Backend/FroshEnvironmentNoticeEditorApi.php
@@ -4,10 +4,16 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
 use FroshEnvironmentNotice\Models\Notice;
 use FroshEnvironmentNotice\Models\Slot;
+use FroshEnvironmentNotice\Models\Trigger;
 use Shopware\Components\CSRFWhitelistAware;
 use Shopware\Components\Model\ModelEntity;
 use Shopware\Components\Model\ModelRepository;
 
+/**
+ * Class Shopware_Controllers_Backend_FroshEnvironmentNoticeEditorApi
+ * TODO use namespace
+ * TODO refactor class by splitting into own resources
+ */
 class Shopware_Controllers_Backend_FroshEnvironmentNoticeEditorApi extends Enlight_Controller_Action implements CSRFWhitelistAware
 {
     /**
@@ -19,6 +25,11 @@ class Shopware_Controllers_Backend_FroshEnvironmentNoticeEditorApi extends Enlig
      * @var ModelRepository
      */
     private $slotRepository;
+
+    /**
+     * @var ModelRepository
+     */
+    private $triggerRepository;
 
     /**
      * {@inheritdoc}
@@ -36,6 +47,11 @@ class Shopware_Controllers_Backend_FroshEnvironmentNoticeEditorApi extends Enlig
             'ajaxSlotsInsert',
             'ajaxSlotsUpdate',
             'ajaxSlotsDelete',
+            'ajaxTriggersGet',
+            'ajaxTriggersList',
+            'ajaxTriggersInsert',
+            'ajaxTriggersUpdate',
+            'ajaxTriggersDelete',
         ];
     }
 
@@ -47,6 +63,7 @@ class Shopware_Controllers_Backend_FroshEnvironmentNoticeEditorApi extends Enlig
         $this->Request()->replacePost(json_decode(file_get_contents('php://input'), true));
         $this->noticeRepository = $this->getModelManager()->getRepository(Notice::class);
         $this->slotRepository = $this->getModelManager()->getRepository(Slot::class);
+        $this->triggerRepository = $this->getModelManager()->getRepository(Trigger::class);
     }
 
     public function postDispatch()
@@ -123,6 +140,31 @@ class Shopware_Controllers_Backend_FroshEnvironmentNoticeEditorApi extends Enlig
     public function ajaxSlotsDeleteAction()
     {
         $this->deleteActionGeneric($this->slotRepository);
+    }
+
+    public function ajaxTriggersListAction()
+    {
+        $this->listActionGeneric($this->triggerRepository);
+    }
+
+    public function ajaxTriggersGetAction()
+    {
+        $this->getActionGeneric($this->triggerRepository);
+    }
+
+    public function ajaxTriggersInsertAction()
+    {
+        $this->insertActionGeneric(Trigger::class);
+    }
+
+    public function ajaxTriggersUpdateAction()
+    {
+        $this->updateActionGeneric($this->triggerRepository);
+    }
+
+    public function ajaxTriggersDeleteAction()
+    {
+        $this->deleteActionGeneric($this->triggerRepository);
     }
 
     /**

--- a/FroshEnvironmentNotice.php
+++ b/FroshEnvironmentNotice.php
@@ -8,6 +8,7 @@ use FroshEnvironmentNotice\Components\Bootstrap\ConditionsCollectionPass;
 use FroshEnvironmentNotice\Components\Bootstrap\NoticeInjectActionCollectionPass;
 use FroshEnvironmentNotice\Models\Notice;
 use FroshEnvironmentNotice\Models\Slot;
+use FroshEnvironmentNotice\Models\Trigger;
 use Shopware\Components\Model\ModelEntity;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Plugin;
@@ -24,6 +25,7 @@ class FroshEnvironmentNotice extends Plugin
     private $modelClasses = [
         Notice::class,
         Slot::class,
+        Trigger::class,
     ];
 
     /**

--- a/FroshEnvironmentNotice.php
+++ b/FroshEnvironmentNotice.php
@@ -88,7 +88,23 @@ class FroshEnvironmentNotice extends Plugin
                 return (new Slot())->fromArray($data);
             }, $datas);
             array_walk($models, [$this->getModelManager(), 'persist']);
-            /** @noinspection PhpUnhandledExceptionInspection */
+            /* @noinspection PhpUnhandledExceptionInspection */
+            $this->getModelManager()->flush($models);
+        }
+
+        $amountOfTrigger = $this->getModelManager()
+            ->getRepository(Trigger::class)
+            ->createQueryBuilder('slot')
+            ->getMaxResults();
+
+        if (!$amountOfTrigger) {
+            $datas = json_decode(file_get_contents($this->getPath() . '/Resources/seeds/triggers.json'), true);
+            /** @var ModelEntity[] $models */
+            $models = array_map(function ($data) {
+                return (new Trigger())->fromArray($data);
+            }, $datas);
+            array_walk($models, [$this->getModelManager(), 'persist']);
+            /* @noinspection PhpUnhandledExceptionInspection */
             $this->getModelManager()->flush($models);
         }
     }

--- a/FroshEnvironmentNotice.php
+++ b/FroshEnvironmentNotice.php
@@ -5,6 +5,7 @@ namespace FroshEnvironmentNotice;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
 use FroshEnvironmentNotice\Components\Bootstrap\ConditionsCollectionPass;
+use FroshEnvironmentNotice\Components\Bootstrap\NoticeInjectActionCollectionPass;
 use FroshEnvironmentNotice\Models\Notice;
 use FroshEnvironmentNotice\Models\Slot;
 use Shopware\Components\Model\ModelEntity;
@@ -61,6 +62,7 @@ class FroshEnvironmentNotice extends Plugin
     {
         parent::build($container);
         $container->addCompilerPass(new ConditionsCollectionPass());
+        $container->addCompilerPass(new NoticeInjectActionCollectionPass());
     }
 
     private function installSchema()

--- a/FroshEnvironmentNotice.php
+++ b/FroshEnvironmentNotice.php
@@ -4,6 +4,7 @@ namespace FroshEnvironmentNotice;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
+use FroshEnvironmentNotice\Components\Bootstrap\ConditionsCollectionPass;
 use FroshEnvironmentNotice\Models\Notice;
 use FroshEnvironmentNotice\Models\Slot;
 use Shopware\Components\Model\ModelEntity;
@@ -12,6 +13,7 @@ use Shopware\Components\Plugin;
 use Shopware\Components\Plugin\Context\InstallContext;
 use Shopware\Components\Plugin\Context\UninstallContext;
 use Shopware\Components\Plugin\Context\UpdateContext;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class FroshEnvironmentNotice extends Plugin
 {
@@ -50,6 +52,15 @@ class FroshEnvironmentNotice extends Plugin
     {
         parent::uninstall($context);
         $this->uninstallSchema();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new ConditionsCollectionPass());
     }
 
     private function installSchema()

--- a/Interfaces/ConditionInterface.php
+++ b/Interfaces/ConditionInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Interfaces;
+
+/**
+ * Interface ConditionInterface
+ */
+interface ConditionInterface
+{
+    /**
+     * @return bool
+     */
+    public function isMet(array $configuration): bool;
+}

--- a/Interfaces/NoticeInjectActionInterface.php
+++ b/Interfaces/NoticeInjectActionInterface.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Interfaces;
+
+/**
+ * Interface NoticeInjectActionInterface
+ */
+interface NoticeInjectActionInterface
+{
+    /**
+     * @param array $configuration
+     * @param mixed $response
+     * @return mixed
+     */
+    public function injectNotice(array $configuration, $response);
+}

--- a/Models/Trigger.php
+++ b/Models/Trigger.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Models;
+
+use Doctrine\ORM\Mapping as ORM;
+use JsonSerializable;
+use Shopware\Components\Model\ModelEntity;
+
+/**
+ * Class Trigger
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="frosh_environment_notice_triggers")
+ */
+class Trigger extends ModelEntity implements JsonSerializable
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id()
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="condition_type", type="string", nullable=false)
+     */
+    private $conditionType;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="condition_configuration", type="string", nullable=false)
+     */
+    private $conditionConfiguration;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="action_type", type="string", nullable=false)
+     */
+    private $actionType;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="action_configuration", type="string", nullable=false)
+     */
+    private $actionConfiguration;
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConditionType(): string
+    {
+        return $this->conditionType;
+    }
+
+    /**
+     * @param string $conditionType
+     *
+     * @return Trigger
+     */
+    public function setConditionType(string $conditionType): Trigger
+    {
+        $this->conditionType = $conditionType;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConditionConfiguration(): string
+    {
+        return $this->conditionConfiguration;
+    }
+
+    /**
+     * @param string $conditionConfiguration
+     *
+     * @return Trigger
+     */
+    public function setConditionConfiguration(string $conditionConfiguration): Trigger
+    {
+        $this->conditionConfiguration = $conditionConfiguration;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActionType(): string
+    {
+        return $this->actionType;
+    }
+
+    /**
+     * @param string $actionType
+     *
+     * @return Trigger
+     */
+    public function setActionType(string $actionType): Trigger
+    {
+        $this->actionType = $actionType;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActionConfiguration(): string
+    {
+        return $this->actionConfiguration;
+    }
+
+    /**
+     * @param string $actionConfiguration
+     *
+     * @return Trigger
+     */
+    public function setActionConfiguration(string $actionConfiguration): Trigger
+    {
+        $this->actionConfiguration = $actionConfiguration;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+}

--- a/Resources/seeds/triggers.json
+++ b/Resources/seeds/triggers.json
@@ -1,0 +1,14 @@
+[
+  {
+    "conditionType": "FroshEnvironmentNotice\\Services\\Conditions\\RequestedModuleCondition",
+    "conditionConfiguration": "{\"module\": \"frontend\"}",
+    "actionType": "FroshEnvironmentNotice\\Services\\NoticeInjectActions\\HtmlResponseSlotNoticeInjectAction",
+    "actionConfiguration": "{\"name\": \"frontend\"}"
+  },
+  {
+    "conditionType": "FroshEnvironmentNotice\\Services\\Conditions\\RequestedModuleCondition",
+    "conditionConfiguration": "{\"module\": \"backend\"}",
+    "actionType": "FroshEnvironmentNotice\\Services\\NoticeInjectActions\\HtmlResponseSlotNoticeInjectAction",
+    "actionConfiguration": "{\"name\": \"backend\"}"
+  }
+]

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -40,5 +40,11 @@
             <tag name="frosh_environment_notice.condition"/>
             <argument type="service" id="service_container"/>
         </service>
+        <service class="FroshEnvironmentNotice\Services\NoticeInjectActions\HtmlResponseSlotNoticeInjectAction" id="frosh_environment_notice.services.notice_inject_actions.html_response_slot_notice_inject_action">
+            <tag name="frosh_environment_notice.notice_inject_action"/>
+            <argument type="service" id="frosh.environment_notice.services.modify_html_text"/>
+            <argument type="service" id="frosh.environment_notice.services.notice_markup_builder"/>
+            <argument type="service" id="frosh.environment_notice.repository.notice"/>
+        </service>
     </services>
 </container>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -10,9 +10,9 @@
         <!-- Subscribers -->
         <service id="frosh.environment_notice.subscriber.notice_injection" class="FroshEnvironmentNotice\Subscriber\NoticeInjection">
             <tag name="shopware.event_subscriber" />
-            <argument type="service" id="frosh.environment_notice.services.modify_html_text"/>
-            <argument type="service" id="frosh.environment_notice.services.notice_markup_builder"/>
-            <argument type="service" id="frosh.environment_notice.repository.notice"/>
+            <argument type="service" id="frosh_environment_notice.services.conditions"/>
+            <argument type="service" id="frosh_environment_notice.services.notice_inject_actions"/>
+            <argument type="service" id="frosh.environment_notice.repository.trigger"/>
         </service>
 
         <!-- Repository -->

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -33,5 +33,8 @@
         <service id="frosh_environment_notice.services.conditions" class="Doctrine\Common\Collections\ArrayCollection">
             <argument type="collection"/>
         </service>
+        <service id="frosh_environment_notice.services.notice_inject_actions" class="Doctrine\Common\Collections\ArrayCollection">
+            <argument type="collection"/>
+        </service>
     </services>
 </container>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -24,6 +24,10 @@
             <factory service="models" method="getRepository"/>
             <argument type="string">FroshEnvironmentNotice\Models\Slot</argument>
         </service>
+        <service id="frosh.environment_notice.repository.trigger" class="Shopware\Components\Model\ModelRepository">
+            <factory service="models" method="getRepository"/>
+            <argument type="string">FroshEnvironmentNotice\Models\Trigger</argument>
+        </service>
 
         <!-- Services -->
         <service id="frosh.environment_notice.services.modify_html_text" class="FroshEnvironmentNotice\Services\ModifyHtmlText"/>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -36,5 +36,9 @@
         <service id="frosh_environment_notice.services.notice_inject_actions" class="Doctrine\Common\Collections\ArrayCollection">
             <argument type="collection"/>
         </service>
+        <service id="frosh_environment_notice.services.conditions.requested_module_condition" class="FroshEnvironmentNotice\Services\Conditions\RequestedModuleCondition">
+            <tag name="frosh_environment_notice.condition"/>
+            <argument type="service" id="service_container"/>
+        </service>
     </services>
 </container>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -30,5 +30,8 @@
         <service id="frosh.environment_notice.services.notice_markup_builder" class="FroshEnvironmentNotice\Services\NoticeMarkupBuilder">
             <argument type="service" id="oyejorge_compiler"/>
         </service>
+        <service id="frosh_environment_notice.services.conditions" class="Doctrine\Common\Collections\ArrayCollection">
+            <argument type="collection"/>
+        </service>
     </services>
 </container>

--- a/Resources/views/backend/frosh_environment_notice_editor/app.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/app.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor', {
     extend:'Enlight.app.SubApplication',
     name:'Shopware.apps.FroshEnvironmentNoticeEditor',

--- a/Resources/views/backend/frosh_environment_notice_editor/app.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/app.js
@@ -5,7 +5,18 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor', {
     loadPath: '{url action=load}',
     controllers: ['Main'],
     models: [ 'Slots', 'Messages', 'Triggers' ],
-    views: [ 'Window', 'grid.Slots', 'grid.Messages', 'detail.Slot', 'detail.Message', 'detail.SlotWindow', 'detail.MessageWindow', 'grid.Triggers' ],
+    views: [
+        'Window',
+        'grid.Slots',
+        'grid.Messages',
+        'grid.Triggers',
+        'detail.Slot',
+        'detail.Message',
+        'detail.Trigger',
+        'detail.SlotWindow',
+        'detail.MessageWindow',
+        'detail.TriggerWindow'
+    ],
     stores: [ 'Slots', 'Messages', 'Triggers' ],
 
     /** Main Function

--- a/Resources/views/backend/frosh_environment_notice_editor/app.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/app.js
@@ -5,7 +5,7 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor', {
     loadPath: '{url action=load}',
     controllers: ['Main'],
     models: [ 'Slots', 'Messages', 'Triggers' ],
-    views: [ 'Window', 'grid.Slots', 'grid.Messages', 'detail.Slot', 'detail.Message', 'detail.SlotWindow', 'detail.MessageWindow' ],
+    views: [ 'Window', 'grid.Slots', 'grid.Messages', 'detail.Slot', 'detail.Message', 'detail.SlotWindow', 'detail.MessageWindow', 'grid.Triggers' ],
     stores: [ 'Slots', 'Messages', 'Triggers' ],
 
     /** Main Function

--- a/Resources/views/backend/frosh_environment_notice_editor/app.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/app.js
@@ -4,7 +4,7 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor', {
     bulkLoad: true,
     loadPath: '{url action=load}',
     controllers: ['Main'],
-    models: [ 'Slots', 'Messages' ],
+    models: [ 'Slots', 'Messages', 'Triggers' ],
     views: [ 'Window', 'grid.Slots', 'grid.Messages', 'detail.Slot', 'detail.Message', 'detail.SlotWindow', 'detail.MessageWindow' ],
     stores: [ 'Slots', 'Messages' ],
 

--- a/Resources/views/backend/frosh_environment_notice_editor/app.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/app.js
@@ -6,7 +6,7 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor', {
     controllers: ['Main'],
     models: [ 'Slots', 'Messages', 'Triggers' ],
     views: [ 'Window', 'grid.Slots', 'grid.Messages', 'detail.Slot', 'detail.Message', 'detail.SlotWindow', 'detail.MessageWindow' ],
-    stores: [ 'Slots', 'Messages' ],
+    stores: [ 'Slots', 'Messages', 'Triggers' ],
 
     /** Main Function
      * @private

--- a/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
@@ -1,3 +1,4 @@
+/* TODO refactor duplicate code */
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
 
     extend: 'Ext.app.Controller',
@@ -35,6 +36,11 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
                     this.onSlotSave(btn);
                 }
             },
+            'env-notice-editor-detail-trigger button[action=save]': {
+                'click': function(btn) {
+                    this.onTriggerSave(btn);
+                }
+            },
             'env-notice-editor-messages-grid button[action=addMessage]': {
                 'click': function (btn) {
                     this.addMessage(btn);
@@ -45,6 +51,11 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
                     this.addSlot(btn);
                 }
             },
+            'env-notice-editor-triggers-grid button[action=addTrigger]': {
+                'click': function (btn) {
+                    this.addTrigger(btn);
+                }
+            },
             'env-notice-editor-messages-grid': {
                 openMessageDetail: me.openMessageDetail,
                 deleteMessage: me.deleteMessage
@@ -52,6 +63,10 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
             'env-notice-editor-slots-grid': {
                 openSlotDetail: me.openSlotDetail,
                 deleteSlot: me.deleteSlot
+            },
+            'env-notice-editor-triggers-grid': {
+                openSlotDetail: me.openTriggerDetail,
+                deleteSlot: me.deleteTrigger
             }
         });
 
@@ -113,6 +128,34 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
         }
     },
 
+    onTriggerSave: function (btn) {
+        var me = this,
+            win = btn.up('window'),
+            form = win.down('form'),
+            formBasis = form.getForm(),
+            store = me.getStore('Triggers'),
+            record = formBasis.getRecord();
+
+        formBasis.updateRecord(record);
+
+        if (formBasis.isValid()) {
+            record.save({
+                success: function() {
+                    store.load();
+                    win.close();
+                    Shopware.Msg.createGrowlMessage('','{s name="FroshEnvironmentNoticeEditorTriggerSave"}Trigger saved{/s}', '');
+                },
+                failure: function() {
+                    store.load();
+                    win.close();
+                    Shopware.Msg.createGrowlMessage('',
+                        '{s name="FroshEnvironmentNoticeEditorTriggerSaveError"}Error saving trigger{/s}',
+                        '');
+                }
+            });
+        }
+    },
+
     addMessage: function () {
         var me = this;
 
@@ -130,6 +173,16 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
         me.record = Ext.create('Shopware.apps.FroshEnvironmentNoticeEditor.model.Slots');
 
         me.getView('detail.SlotWindow').create({
+            record: me.record
+        }).show();
+    },
+
+    addTrigger: function () {
+        var me = this;
+
+        me.record = Ext.create('Shopware.apps.FroshEnvironmentNoticeEditor.model.Triggers');
+
+        me.getView('detail.TriggerWindow').create({
             record: me.record
         }).show();
     },
@@ -179,6 +232,37 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
     deleteSlot: function (view, rowIndex) {
         var me = this,
             store = me.getStore('Slots');
+
+        me.record = store.getAt(rowIndex);
+
+        if (me.record instanceof Ext.data.Model && me.record.get('id') > 0) {
+            Ext.MessageBox.confirm('', '{s name="FroshEnvironmentNoticeEditorDeleteWarning"}Are you sure you want to delete?{/s}' , function (response) {
+                if ( response !== 'yes' ) {
+                    return;
+                }
+                me.record.destroy({
+                    callback: function() {
+                        Shopware.Msg.createGrowlMessage('','{s name="FroshEnvironmentNoticeEditorDeleteSuccess"}Entry was deleted{/s}', '');
+                        store.load();
+                    }
+                });
+            });
+        }
+    },
+
+    openTriggerDetail: function (view, rowIndex) {
+        var me = this;
+
+        me.record = me.getStore('Triggers').getAt(rowIndex);
+
+        me.getView('detail.TriggerWindow').create({
+            record: me.record
+        }).show();
+    },
+
+    deleteTrigger: function (view, rowIndex) {
+        var me = this,
+            store = me.getStore('Triggers');
 
         me.record = store.getAt(rowIndex);
 

--- a/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
@@ -16,7 +16,8 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
                     callback: function() {
                         me.mainWindow = me.getView('Window').create({
                             messagesStore: me.getStore('Messages'),
-                            slotsStore: me.getStore('Slots')
+                            slotsStore: me.getStore('Slots'),
+                            triggersStore: me.getStore('Triggers'),
                         });
                     }
                 });

--- a/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
@@ -1,4 +1,5 @@
-/* TODO refactor duplicate code */
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
 
     extend: 'Ext.app.Controller',

--- a/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/controller/main.js
@@ -8,19 +8,10 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
     init: function() {
         var me = this;
 
-        me.getStore('Messages').load({
-            scope: this,
-            callback: function() {
-                me.getStore('Slots').load({
-                    scope: this,
-                    callback: function() {
-                        me.mainWindow = me.getView('Window').create({
-                            messagesStore: me.getStore('Messages'),
-                            slotsStore: me.getStore('Slots')
-                        });
-                    }
-                });
-            }
+        me.mainWindow = me.getView('Window').create({
+            messagesStore: me.getStore('Messages'),
+            slotsStore: me.getStore('Slots'),
+            triggersStore: me.getStore('Triggers')
         });
 
         me.callParent(arguments);
@@ -65,8 +56,8 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.controller.Main', {
                 deleteSlot: me.deleteSlot
             },
             'env-notice-editor-triggers-grid': {
-                openSlotDetail: me.openTriggerDetail,
-                deleteSlot: me.deleteTrigger
+                openTriggerDetail: me.openTriggerDetail,
+                deleteTrigger: me.deleteTrigger
             }
         });
 

--- a/Resources/views/backend/frosh_environment_notice_editor/model/messages.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/model/messages.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.model.Messages', {
     extend : 'Ext.data.Model', 
     fields : [

--- a/Resources/views/backend/frosh_environment_notice_editor/model/slots.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/model/slots.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.model.Slots', {
     extend : 'Ext.data.Model', 
     fields : [

--- a/Resources/views/backend/frosh_environment_notice_editor/model/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/model/triggers.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.model.Triggers', {
     extend : 'Ext.data.Model', 
     fields : [

--- a/Resources/views/backend/frosh_environment_notice_editor/model/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/model/triggers.js
@@ -1,0 +1,40 @@
+Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.model.Triggers', {
+    extend : 'Ext.data.Model', 
+    fields : [
+        {
+            name: 'id',
+            type: 'int',
+            useNull: true
+        },
+        {
+            name: 'conditionType',
+            type: 'string'
+        },
+        {
+            name: 'conditionConfiguration',
+            type: 'string'
+        },
+        {
+            name: 'actionType',
+            type: 'string'
+        },
+        {
+            name: 'actionConfiguration',
+            type: 'string'
+        }
+    ],
+    idProperty: 'id',
+    proxy: {
+        type : 'ajax',
+        api:{
+            create : '{url controller="FroshEnvironmentNoticeEditorApi" action="ajaxTriggersInsert"}',
+            update : '{url controller="FroshEnvironmentNoticeEditorApi" action="ajaxTriggersUpdate"}',
+            destroy : '{url controller="FroshEnvironmentNoticeEditorApi" action="ajaxTriggersDelete"}'
+        },
+        reader : {
+            type : 'json',
+            root : 'data',
+            totalProperty: 'totalCount'
+        }
+    }
+});

--- a/Resources/views/backend/frosh_environment_notice_editor/store/messages.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/messages.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Messages', {
     extend: 'Ext.data.Store',
     remoteFilter: true,

--- a/Resources/views/backend/frosh_environment_notice_editor/store/messages.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/messages.js
@@ -1,7 +1,7 @@
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Messages', {
     extend: 'Ext.data.Store',
     remoteFilter: true,
-    autoLoad : false,
+    autoLoad : true,
     model : 'Shopware.apps.FroshEnvironmentNoticeEditor.model.Messages',
     pageSize: 20,
     proxy: {

--- a/Resources/views/backend/frosh_environment_notice_editor/store/slots.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/slots.js
@@ -1,7 +1,7 @@
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Slots', {
     extend: 'Ext.data.Store',
     remoteFilter: true,
-    autoLoad : false,
+    autoLoad : true,
     model : 'Shopware.apps.FroshEnvironmentNoticeEditor.model.Slots',
     pageSize: 20,
     proxy: {

--- a/Resources/views/backend/frosh_environment_notice_editor/store/slots.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/slots.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Slots', {
     extend: 'Ext.data.Store',
     remoteFilter: true,

--- a/Resources/views/backend/frosh_environment_notice_editor/store/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/triggers.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Triggers', {
     extend: 'Ext.data.Store',
     remoteFilter: true,

--- a/Resources/views/backend/frosh_environment_notice_editor/store/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/triggers.js
@@ -1,0 +1,15 @@
+Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Triggers', {
+    extend: 'Ext.data.Store',
+    remoteFilter: true,
+    autoLoad : false,
+    model : 'Shopware.apps.FroshEnvironmentNoticeEditor.model.Triggers',
+    pageSize: 20,
+    proxy: {
+        type: 'ajax',
+        url: '{url controller="FroshEnvironmentNoticeEditorApi" action="ajaxTriggersList"}',
+        reader: {
+            type: 'json',
+            root: 'items'
+        }
+    }
+});

--- a/Resources/views/backend/frosh_environment_notice_editor/store/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/store/triggers.js
@@ -1,7 +1,7 @@
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.store.Triggers', {
     extend: 'Ext.data.Store',
     remoteFilter: true,
-    autoLoad : false,
+    autoLoad : true,
     model : 'Shopware.apps.FroshEnvironmentNoticeEditor.model.Triggers',
     pageSize: 20,
     proxy: {

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/message.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/message.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.Message', {
     extend:'Ext.form.Panel',
     alias:'widget.env-notice-editor-detail-message',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/message_window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/message_window.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.MessageWindow', {
     extend: 'Enlight.app.Window',
     title: '{s name="FroshEnvironmentNoticeEditorMessageTitle"}Message{/s}',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/slot.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/slot.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.Slot', {
     extend:'Ext.form.Panel',
     alias:'widget.env-notice-editor-detail-slot',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/slot_window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/slot_window.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.SlotWindow', {
     extend: 'Enlight.app.Window',
     title: '{s name="FroshEnvironmentNoticeEditorSlotTitle"}Slot{/s}',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.Trigger', {
     extend:'Ext.form.Panel',
     alias:'widget.env-notice-editor-detail-trigger',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger.js
@@ -1,0 +1,91 @@
+Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.Trigger', {
+    extend:'Ext.form.Panel',
+    alias:'widget.env-notice-editor-detail-trigger',
+    collapsible: false,
+    bodyPadding: 10,
+    split: false,
+    region: 'center',
+    defaultType: 'textfield',
+    autoScroll: true,
+    layout: {
+        type: 'vbox',
+        align : 'stretch',
+        pack  : 'start'
+    },
+    items : [],
+    initComponent: function() {
+        var me = this;
+        
+        me.dockedItems = [
+            {
+                xtype: 'toolbar',
+                dock: 'bottom',
+                cls: 'shopware-toolbar',
+                ui: 'shopware-ui',
+                items: me.getButtons()
+            }
+        ];
+        
+        me.items = me.getItems();
+        
+        me.callParent(arguments);
+        me.loadRecord(me.record);
+    },  
+    getItems:function () {
+        var me = this;
+        return [
+            {
+                fieldLabel: '{s name="FroshEnvironmentNoticeEditorTriggerConditionTypeLabel"}Type of condition{/s}',
+                labelWidth: 150,
+                anchor: '100%',
+                name: 'conditionType',
+                allowBlank: false
+            },
+            {
+                fieldLabel: '{s name="FroshEnvironmentNoticeEditorTriggerConditionConfigurationLabel"}Condition configuration{/s}',
+                labelWidth: 150,
+                anchor: '100%',
+                name: 'conditionConfiguration',
+                allowBlank: false
+            },
+            {
+                fieldLabel: '{s name="FroshEnvironmentNoticeEditorTriggerActionTypeLabel"}Type of action{/s}',
+                labelWidth: 150,
+                anchor: '100%',
+                name: 'actionType',
+                allowBlank: false
+            },
+            {
+                fieldLabel: '{s name="FroshEnvironmentNoticeEditorTriggerActionConfigurationLabel"}Action configuration{/s}',
+                labelWidth: 150,
+                anchor: '100%',
+                name: 'actionConfiguration',
+                allowBlank: false
+            }
+        ];
+    },
+    getButtons : function()
+    {
+        var me = this;
+        return [
+            '->',
+            {
+                text: '{s name="FroshEnvironmentNoticeEditorCancel"}Cancel{/s}',
+                scope: me,
+                cls: 'secondary',
+                handler: function() {
+                    var me = this,
+                        win = me.up('window');
+
+                    win.destroy();
+                }
+            },
+            {
+                text: '{s name="FroshEnvironmentNoticeEditorSave"}Save{/s}',
+                action: 'save',
+                cls: 'primary',
+                formBind: true
+            }
+        ];
+    }
+});

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger_window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger_window.js
@@ -1,0 +1,23 @@
+Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.TriggerWindow', {
+    extend: 'Enlight.app.Window',
+    title: '{s name="FroshEnvironmentNoticeEditorTriggerTitle"}Trigger{/s}',
+    alias: 'widget.env-notice-editor-detail-trigger-window',
+    border: false,
+    autoShow: true,
+    layout: 'fit',
+    height: 500,
+    width: 800,
+    modal: true,
+    initComponent: function() {
+        var me = this;
+        
+        me.items = [
+            {
+                xtype: 'env-notice-editor-detail-trigger',
+                record: me.record
+            }
+        ];
+
+        me.callParent(arguments);
+    }
+});

--- a/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger_window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/detail/trigger_window.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.detail.TriggerWindow', {
     extend: 'Enlight.app.Window',
     title: '{s name="FroshEnvironmentNoticeEditorTriggerTitle"}Trigger{/s}',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/grid/messages.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/grid/messages.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.grid.Messages', {
     extend:'Ext.grid.Panel',
     border: false,

--- a/Resources/views/backend/frosh_environment_notice_editor/view/grid/slots.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/grid/slots.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.grid.Slots', {
     extend:'Ext.grid.Panel',
     border: false,

--- a/Resources/views/backend/frosh_environment_notice_editor/view/grid/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/grid/triggers.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.grid.Triggers', {
     extend:'Ext.grid.Panel',
     border: false,

--- a/Resources/views/backend/frosh_environment_notice_editor/view/grid/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/grid/triggers.js
@@ -1,0 +1,77 @@
+Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.grid.Triggers', {
+    extend:'Ext.grid.Panel',
+    border: false,
+    alias:'widget.env-notice-editor-triggers-grid',
+    region:'center',
+    autoScroll:true,
+    title: '{s name="FroshEnvironmentNoticeEditorTriggersGridTitle"}Triggers{/s}',
+    initComponent:function () {
+        var me = this;
+        me.columns = me.getColumns();
+        me.dockedItems = [
+                {
+                    xtype: 'toolbar',
+                    dock: 'top',
+                    cls: 'shopware-toolbar',
+                    ui: 'shopware-ui',
+                    items: me.getButtons()
+                }
+            ];
+        me.callParent(arguments);
+    },
+    getColumns:function () {
+        var me = this;
+
+        return [
+            {
+                header: '{s name="FroshEnvironmentNoticeEditorTriggerConditionTypeLabel"}Type of condition{/s}',
+                flex: 1,
+                dataIndex: 'conditionType'
+            },
+            {
+                header: '{s name="FroshEnvironmentNoticeEditorTriggerConditionConfigurationLabel"}Condition configuration{/s}',
+                flex: 1,
+                dataIndex: 'conditionConfiguration'
+            },
+            {
+                header: '{s name="FroshEnvironmentNoticeEditorTriggerActionTypeLabel"}Type of action{/s}',
+                flex: 1,
+                dataIndex: 'actionType'
+            },
+            {
+                header: '{s name="FroshEnvironmentNoticeEditorTriggerActionConfigurationLabel"}Action configuration{/s}',
+                flex: 1,
+                dataIndex: 'actionConfiguration'
+            },
+            {
+                xtype: 'actioncolumn',
+                width: 60,
+                items: me.getActionColumnItems()
+            }
+        ];
+    },
+    getActionColumnItems: function () {
+        var me = this;
+
+        return [
+            {
+                iconCls:'x-action-col-icon sprite-minus-circle-frame',
+                tooltip:'{s name="FroshEnvironmentNoticeEditorDelete"}Delete{/s}',
+                getClass: function(value, metadata, record) {
+                    if (!record.get("id")) {
+                        return 'x-hidden';
+                    }
+                },
+                handler:function (view, rowIndex, colIndex, item) {
+                    me.fireEvent('deleteTrigger', view, rowIndex, colIndex, item);
+                }
+            }
+        ];
+    },
+    getButtons : function() {
+        var me = this;
+
+        return [
+        ];
+    }
+});

--- a/Resources/views/backend/frosh_environment_notice_editor/view/grid/triggers.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/grid/triggers.js
@@ -55,6 +55,18 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.grid.Triggers', {
 
         return [
             {
+                iconCls:'x-action-col-icon sprite-pencil',
+                tooltip:'{s name="FroshEnvironmentNoticeEditorEdit"}Edit{/s}',
+                getClass: function(value, metadata, record) {
+                    if (!record.get("id")) {
+                        return 'x-hidden';
+                    }
+                },
+                handler:function (view, rowIndex, colIndex, item) {
+                    me.fireEvent('openTriggerDetail', view, rowIndex, colIndex, item);
+                }
+            },
+            {
                 iconCls:'x-action-col-icon sprite-minus-circle-frame',
                 tooltip:'{s name="FroshEnvironmentNoticeEditorDelete"}Delete{/s}',
                 getClass: function(value, metadata, record) {
@@ -72,6 +84,12 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.grid.Triggers', {
         var me = this;
 
         return [
+            {
+                text: '{s name="FroshEnvironmentNoticeEditorAdd"}Add{/s}',
+                scope: me,
+                iconCls: 'sprite-plus-circle-frame',
+                action: 'addTrigger'
+            }
         ];
     }
 });

--- a/Resources/views/backend/frosh_environment_notice_editor/view/window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/window.js
@@ -16,6 +16,12 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.Window', {
                 flex: 1,
                 items: [
                     {
+                        title: '{s name="FroshEnvironmentNoticeEditorTriggersGridTitle"}Triggers{/s}',
+                        xtype: 'env-notice-editor-triggers-grid',
+                        store: me.triggersStore,
+                        flex: 1
+                    },
+                    {
                         title: '{s name="FroshEnvironmentNoticeEditorMessagesGridTitle"}Messages{/s}',
                         xtype: 'env-notice-editor-messages-grid',
                         store: me.messagesStore,

--- a/Resources/views/backend/frosh_environment_notice_editor/view/window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/window.js
@@ -1,3 +1,5 @@
+//{namespace name=backend/plugins/frosh_environment_notice_editor}
+//
 Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.Window', {
     extend: 'Enlight.app.Window',
     title: '{s name="FroshEnvironmentNoticeEditorTitle"}Environment Notices{/s}',

--- a/Resources/views/backend/frosh_environment_notice_editor/view/window.js
+++ b/Resources/views/backend/frosh_environment_notice_editor/view/window.js
@@ -16,15 +16,15 @@ Ext.define('Shopware.apps.FroshEnvironmentNoticeEditor.view.Window', {
                 flex: 1,
                 items: [
                     {
-                        title: '{s name="FroshEnvironmentNoticeEditorTriggersGridTitle"}Triggers{/s}',
-                        xtype: 'env-notice-editor-triggers-grid',
-                        store: me.triggersStore,
-                        flex: 1
-                    },
-                    {
                         title: '{s name="FroshEnvironmentNoticeEditorMessagesGridTitle"}Messages{/s}',
                         xtype: 'env-notice-editor-messages-grid',
                         store: me.messagesStore,
+                        flex: 1
+                    },
+                    {
+                        title: '{s name="FroshEnvironmentNoticeEditorTriggersGridTitle"}Triggers{/s}',
+                        xtype: 'env-notice-editor-triggers-grid',
+                        store: me.triggersStore,
                         flex: 1
                     },
                     {

--- a/Services/Conditions/RequestedModuleCondition.php
+++ b/Services/Conditions/RequestedModuleCondition.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Services\Conditions;
+
+use Enlight_Controller_Front;
+use FroshEnvironmentNotice\Interfaces\ConditionInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class RequestedModuleCondition
+ */
+class RequestedModuleCondition implements ConditionInterface
+{
+    const MODULE_NAME = 'module';
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * RequestedModuleCondition constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @return bool
+     * @noinspection PhpUnhandledExceptionInspection
+     */
+    public function isMet(array $configuration): bool
+    {
+        if (!array_key_exists(self::MODULE_NAME, $configuration)) {
+            return false;
+        }
+
+        /** @var Enlight_Controller_Front|null $front */
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $front = $this->container->get('front', Container::NULL_ON_INVALID_REFERENCE);
+
+        if (is_null($front)) {
+            return false;
+        }
+
+        return strcasecmp($front->Request()->getModuleName(), $configuration[self::MODULE_NAME]) === 0;
+    }
+}

--- a/Services/NoticeInjectActions/HtmlResponseSlotNoticeInjectAction.php
+++ b/Services/NoticeInjectActions/HtmlResponseSlotNoticeInjectAction.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace FroshEnvironmentNotice\Services\NoticeInjectActions;
+
+use FroshEnvironmentNotice\Interfaces\NoticeInjectActionInterface;
+use FroshEnvironmentNotice\Models\Notice;
+use FroshEnvironmentNotice\Models\Slot;
+use FroshEnvironmentNotice\Services\ModifyHtmlText;
+use FroshEnvironmentNotice\Services\NoticeMarkupBuilder;
+use Shopware\Components\Model\ModelRepository;
+
+/**
+ * Class HtmlResponseSlotNoticeInjectAction
+ */
+class HtmlResponseSlotNoticeInjectAction implements NoticeInjectActionInterface
+{
+    const NOTICE_NAME = 'name';
+
+    /**
+     * @var NoticeMarkupBuilder
+     */
+    private $noticeMarkupBuilder;
+
+    /**
+     * @var ModifyHtmlText
+     */
+    private $modifyHtmlText;
+
+    /**
+     * @var ModelRepository
+     */
+    private $noticeRepository;
+
+    /**
+     * HtmlResponseSlotNoticeInjectAction constructor.
+     * @param ModifyHtmlText $modifyHtmlText
+     * @param NoticeMarkupBuilder $noticeMarkupBuilder
+     * @param ModelRepository $noticeRepository
+     */
+    public function __construct(
+        ModifyHtmlText $modifyHtmlText,
+        NoticeMarkupBuilder $noticeMarkupBuilder,
+        ModelRepository $noticeRepository
+    ) {
+        $this->noticeRepository = $noticeRepository;
+        $this->modifyHtmlText = $modifyHtmlText;
+        $this->noticeMarkupBuilder = $noticeMarkupBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function injectNotice(array $configuration, $response)
+    {
+        // TODO allow multiple execution of this method without creating overlapping notices
+
+        if (!is_string($response) || stripos($response, '</body') === false) {
+            return $response;
+        }
+
+        $notices = $this->getMatchingNotices($configuration);
+        $slots = $this->groupNoticesBySlots($notices);
+
+        foreach ($slots as $slot) {
+            /** @var Slot $slotItem */
+            $slotItem = $slot['slot'];
+
+            $messages = array_map(function (Notice $notice) {
+                return $notice->getMessage();
+            }, $slot['items']);
+
+            $response = $this->modifyHtmlText->insertAfterTag(
+                'body',
+                $this->noticeMarkupBuilder->buildNoticeInSlot(join(PHP_EOL, $messages), $slotItem),
+                $response
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param array $configuration
+     * @return Notice[]
+     */
+    protected function getMatchingNotices(array $configuration)
+    {
+        if (!array_key_exists(self::NOTICE_NAME, $configuration)) {
+            return [];
+        }
+
+        return $this->noticeRepository->findBy([
+            'name' => $configuration[self::NOTICE_NAME],
+        ]);
+    }
+
+    /**
+     * @param Notice[] $notices
+     * @return array
+     */
+    protected function groupNoticesBySlots(array $notices): array
+    {
+        $slots = [];
+
+        foreach ($notices as $notice) {
+            if (array_key_exists($notice->getSlot()->getId(), $slots)) {
+                $slots[$notice->getSlot()->getId()]['items'][] = $notice;
+            } else {
+                $slots[$notice->getSlot()->getId()] = [
+                    'slot' => $notice->getSlot(),
+                    'items' => [$notice],
+                ];
+            }
+        }
+        return $slots;
+    }
+}

--- a/Subscriber/NoticeInjection.php
+++ b/Subscriber/NoticeInjection.php
@@ -65,10 +65,6 @@ class NoticeInjection implements SubscriberInterface
 
         $module = strtolower($bootstrap->Front()->Request()->getModuleName());
 
-        if ($module === 'widget') {
-            return;
-        }
-
         /** @var Trigger $trigger */
         foreach ($this->triggerRepository->findAll() as $trigger) {
             if (!is_null($condition = $this->getCondition($trigger->getConditionType()))) {

--- a/Subscriber/NoticeInjection.php
+++ b/Subscriber/NoticeInjection.php
@@ -2,44 +2,47 @@
 
 namespace FroshEnvironmentNotice\Subscriber;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Enlight\Event\SubscriberInterface;
 use Enlight_Controller_Plugins_ViewRenderer_Bootstrap;
 use Enlight_Event_EventArgs;
-use FroshEnvironmentNotice\Models\Notice;
-use FroshEnvironmentNotice\Models\Slot;
-use FroshEnvironmentNotice\Services\ModifyHtmlText;
-use FroshEnvironmentNotice\Services\NoticeMarkupBuilder;
+use FroshEnvironmentNotice\Interfaces\ConditionInterface;
+use FroshEnvironmentNotice\Interfaces\NoticeInjectActionInterface;
+use FroshEnvironmentNotice\Models\Trigger;
 use Shopware\Components\Model\ModelRepository;
 
 class NoticeInjection implements SubscriberInterface
 {
     /**
-     * @var ModifyHtmlText
+     * @var ConditionInterface[]
      */
-    private $htmlTextModifier;
+    private $conditions;
 
     /**
-     * @var NoticeMarkupBuilder
+     * @var NoticeInjectActionInterface[]
      */
-    private $markupBuilder;
+    private $noticeInjectActions;
 
     /**
      * @var ModelRepository
      */
-    private $noticeRepository;
+    private $triggerRepository;
 
     /**
      * NoticeInjection constructor.
      *
-     * @param ModifyHtmlText      $htmlTextModifier
-     * @param NoticeMarkupBuilder $markupBuilder
-     * @param ModelRepository     $noticeRepository
+     * @param ArrayCollection $conditions
+     * @param ArrayCollection $noticeInjectActions
+     * @param ModelRepository $triggerRepository
      */
-    public function __construct(ModifyHtmlText $htmlTextModifier, NoticeMarkupBuilder $markupBuilder, ModelRepository $noticeRepository)
-    {
-        $this->htmlTextModifier = $htmlTextModifier;
-        $this->markupBuilder = $markupBuilder;
-        $this->noticeRepository = $noticeRepository;
+    public function __construct(
+        ArrayCollection $conditions,
+        ArrayCollection $noticeInjectActions,
+        ModelRepository $triggerRepository
+    ) {
+        $this->conditions = $conditions->toArray();
+        $this->noticeInjectActions = $noticeInjectActions->toArray();
+        $this->triggerRepository = $triggerRepository;
     }
 
     /**
@@ -66,39 +69,49 @@ class NoticeInjection implements SubscriberInterface
             return;
         }
 
-        /** @var Notice[] $notices */
-        $notices = $this->noticeRepository->findBy([
-            'name' => $module,
-        ]);
+        /** @var Trigger $trigger */
+        foreach ($this->triggerRepository->findAll() as $trigger) {
+            if (!is_null($condition = $this->getCondition($trigger->getConditionType()))) {
+                /** @var array $conditionConfiguration */
+                $conditionConfiguration = json_decode($trigger->getConditionConfiguration(), true);
+                if ($condition->isMet($conditionConfiguration)
+                    && !is_null($action = $this->getNoticeInjectAction($trigger->getActionType()))) {
+                    $actionConfiguration = json_decode($trigger->getActionConfiguration(), true);
+                    $args->setReturn($action->injectNotice($actionConfiguration, $args->getReturn()));
+                }
+            }
+        }
+    }
 
-        $slots = [];
-
-        foreach ($notices as $notice) {
-            if (array_key_exists($notice->getSlot()->getId(), $slots)) {
-                $slots[$notice->getSlot()->getId()]['items'][] = $notice;
-            } else {
-                $slots[$notice->getSlot()->getId()] = [
-                    'slot' => $notice->getSlot(),
-                    'items' => [$notice],
-                ];
+    /**
+     * @param string $conditionType
+     *
+     * @return ConditionInterface|null
+     */
+    protected function getCondition(string $conditionType)
+    {
+        foreach ($this->conditions as $condition) {
+            if (is_a($condition, $conditionType)) {
+                return $condition;
             }
         }
 
-        foreach ($slots as $slot) {
-            /** @var Slot $slotItem */
-            $slotItem = $slot['slot'];
+        return null;
+    }
 
-            $messages = array_map(function (Notice $notice) {
-                return $notice->getMessage();
-            }, $slot['items']);
-
-            $args->setReturn(
-                $this->htmlTextModifier->insertAfterTag(
-                    'body',
-                    $this->markupBuilder->buildNoticeInSlot(join(PHP_EOL, $messages), $slotItem),
-                    $args->getReturn()
-                )
-            );
+    /**
+     * @param string $actionType
+     *
+     * @return NoticeInjectActionInterface|null
+     */
+    protected function getNoticeInjectAction(string $actionType)
+    {
+        foreach ($this->noticeInjectActions as $noticeInjectAction) {
+            if (is_a($noticeInjectAction, $actionType)) {
+                return $noticeInjectAction;
+            }
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR adds support for triggers. These triggers know how to check when they need to trigger and what to do when they are triggered. They are fully extendable by using interfaces and symfony service tags. This will add basic support for #2 and #5 as this makes it extendable by other plugins and makes it easy to add different kind of notices.

This PR lacks an ExtJs editor for triggers. This is an open issue for people which are more familiar with ExtJs as this will get a complicated task as the editor should change the input mask depending on the chosen condition or action of a trigger.